### PR TITLE
Common AMQP Connection Provider + Make SAS package generic

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,76 @@
+package provider
+
+//	MIT License
+//
+//	Copyright (c) Microsoft Corporation. All rights reserved.
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy
+//	of this software and associated documentation files (the "Software"), to deal
+//	in the Software without restriction, including without limitation the rights
+//	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//	copies of the Software, and to permit persons to whom the Software is
+//	furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all
+//	copies or substantial portions of the Software.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//	SOFTWARE
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/Azure/azure-amqp-common-go/auth"
+	"github.com/Azure/azure-amqp-common-go/cbs"
+
+	log "github.com/sirupsen/logrus"
+	"pack.ag/amqp"
+)
+
+type (
+	Provider struct {
+		Endpoint      string
+		TokenProvider auth.TokenProvider
+		Logger        *log.Logger
+	}
+)
+
+func New(endpoint string, tokenProvider auth.TokenProvider) *Provider {
+	p := &Provider{
+		Endpoint:      endpoint,
+		TokenProvider: tokenProvider,
+		Logger:        log.New(),
+	}
+	p.Logger.SetLevel(log.WarnLevel)
+	return p
+}
+
+func (p *Provider) NewConnection() (*amqp.Client, error) {
+	return amqp.Dial(p.GetAmqpHostURI(),
+		amqp.ConnSASLAnonymous(),
+		amqp.ConnMaxSessions(65535),
+		amqp.ConnProperty("product", "MSGolangClient"),
+		amqp.ConnProperty("version", "0.0.1"),
+		amqp.ConnProperty("platform", runtime.GOOS),
+		amqp.ConnProperty("framework", runtime.Version()),
+	)
+}
+
+func (p *Provider) NegotiateClaim(ctx context.Context, conn *amqp.Client, entityPath string) error {
+	audience := p.GetEntityAudience(entityPath)
+	return cbs.NegotiateClaim(ctx, audience, conn, p.TokenProvider)
+}
+
+func (p *Provider) GetAmqpHostURI() string {
+	return "amqps://" + p.Endpoint + "/"
+}
+
+func (p *Provider) GetEntityAudience(entityPath string) string {
+	return p.Endpoint + "/" + entityPath
+}

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -1,27 +1,5 @@
 package uuid
 
-//	MIT License
-//
-//	Copyright (c) Microsoft Corporation. All rights reserved.
-//
-//	Permission is hereby granted, free of charge, to any person obtaining a copy
-//	of this software and associated documentation files (the "Software"), to deal
-//	in the Software without restriction, including without limitation the rights
-//	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//	copies of the Software, and to permit persons to whom the Software is
-//	furnished to do so, subject to the following conditions:
-//
-//	The above copyright notice and this permission notice shall be included in all
-//	copies or substantial portions of the Software.
-//
-//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//	SOFTWARE
-
 import (
 	"crypto/rand"
 	"encoding/hex"
@@ -39,10 +17,14 @@ const (
 	V4
 	_
 
-	VariantNCS byte = iota
+	_ byte = iota
 	VariantRFC4122
-	VariantMicrosoft
-	VariantFuture
+)
+
+type (
+	// UUID representation compliant with specification
+	// described in RFC 4122.
+	UUID [Size]byte
 )
 
 var (
@@ -51,12 +33,6 @@ var (
 	// Nil is special form of UUID that is specified to have all
 	// 128 bits set to zero.
 	Nil = UUID{}
-)
-
-type (
-	// UUID representation compliant with specification
-	// described in RFC 4122.
-	UUID [Size]byte
 )
 
 // NewV4 returns random generated UUID.
@@ -76,18 +52,7 @@ func (u *UUID) setVersion(v byte) {
 }
 
 func (u *UUID) setVariant(v byte) {
-	switch v {
-	case VariantNCS:
-		u[8] = u[8]&(0xff>>1) | (0x00 << 7)
-	case VariantRFC4122:
-		u[8] = u[8]&(0xff>>2) | (0x02 << 6)
-	case VariantMicrosoft:
-		u[8] = u[8]&(0xff>>3) | (0x06 << 5)
-	case VariantFuture:
-		fallthrough
-	default:
-		u[8] = u[8]&(0xff>>3) | (0x07 << 5)
-	}
+	u[8] = u[8]&(0xff>>2) | (0x02 << 6)
 }
 
 func (u UUID) String() string {


### PR DESCRIPTION
I took reference from you namespace struct to create the Provider. Made a few small changes so that it was just a generic AMQP connection provider.

I also modified the sas generation so that it was more generic and can be used for both IoT and Event Hubs. It didn't look like there was any reason to have the namespace in there.

Let me know if I need to fix anything.